### PR TITLE
Alpn

### DIFF
--- a/draft-ietf-quic-v2.md
+++ b/draft-ietf-quic-v2.md
@@ -227,7 +227,7 @@ attempt to use a QUIC version that the server does not support. Therefore, HTTP/
 exception to the principle that new QUIC versions do not require new ALPN
 codepoints.  
 
-Therefore, HTTP/3 servers using QUIC version 2 MUST accept the "h3v2-01" ALPN
+Therefore, HTTP/3 servers using QUIC version 2 MUST accept the "h3q2-01" ALPN
 for QUICv2 connections. Clients SHOULD request this ALPN over QUICv2. Servers
 MAY accept the "h3" ALPN over version 2 to improve compatibility with QUICv2
 clients supporting unmodified applications, but MUST NOT advertise the "h3"
@@ -266,7 +266,7 @@ Application-Layer Protocol Negotiation (ALPN) Protocol IDs registry:
 
 Protocol: HTTP/3 over QUICv2
 
-Identification Sequence: 0x68 0x33 0x76 0x32 ("h3v2")
+Identification Sequence: 0x68 0x33 0x71 0x32 ("h3q2")
 
 Reference: This Document
 

--- a/draft-ietf-quic-v2.md
+++ b/draft-ietf-quic-v2.md
@@ -218,8 +218,10 @@ All QUIC extensions defined to work with version 1 also work with version 2.
 
 ## The HTTP/3 Exception
 
-HTTP/3 can use the ALPN codepoint to discover QUIC versions via the Alt-Svc
-HTTP field {{?RFC7838}}. If different QUIC versions use the same HTTP/3 ALPN, a
+The Alt-Svc HTTP field {{?RFC7838}} allows an HTTP server to inform clients of
+which versions of HTTP it supports. However, in order to use this information, clients
+also need to select a transport protocol that can carry HTTP.
+If multiple QUIC versions were to use the same ALPN to refer to HTTP/3, a
 client might discover QUIC support via Alt-Svc on a TCP connection, and then
 attempt to use a QUIC version that the server does not support. Therefore, HTTP/3 is an
 exception to the principle that new QUIC versions do not require new ALPN

--- a/draft-ietf-quic-v2.md
+++ b/draft-ietf-quic-v2.md
@@ -281,6 +281,7 @@ Reference: This Document
 * Greased the packet type codepoints
 * Random version number
 * Clarified requirement to use QUIC-VN
+* Added new ALPN for h3
 
 ## since draft-duke-quic-v2-02
 

--- a/draft-ietf-quic-v2.md
+++ b/draft-ietf-quic-v2.md
@@ -225,9 +225,9 @@ try QUIC only to find the server is incompatible. Therefore, HTTP/3 is an
 exception to the principle that new QUIC versions do not require new ALPN
 codepoints.  
 
-Therefore, HTTP/3 servers using QUIC version 2 MUST accept the "h3v2" ALPN for
-QUICv2 connections. Clients SHOULD request this ALPN over QUICv2. Servers MAY
-accept the "h3" ALPN over version 2 to improve compatibility with QUICv2
+Therefore, HTTP/3 servers using QUIC version 2 MUST accept the "h3v2-01" ALPN
+for QUICv2 connections. Clients SHOULD request this ALPN over QUICv2. Servers
+MAY accept the "h3" ALPN over version 2 to improve compatibility with QUICv2
 clients supporting unmodified applications, but MUST NOT advertise the "h3"
 ALPN via Alt-Svc unless they also support QUIC version 1.
 

--- a/draft-ietf-quic-v2.md
+++ b/draft-ietf-quic-v2.md
@@ -221,7 +221,7 @@ All QUIC extensions defined to work with version 1 also work with version 2.
 HTTP/3 can use the ALPN codepoint to discover QUIC versions via the Alt-Svc
 HTTP field {{?RFC7838}}. If different QUIC versions use the same HTTP/3 ALPN, a
 client might discover QUIC support via Alt-Svc on a TCP connection, and then
-try QUIC only to find the server is incompatible. Therefore, HTTP/3 is an
+attempt to use a QUIC version that the server does not support. Therefore, HTTP/3 is an
 exception to the principle that new QUIC versions do not require new ALPN
 codepoints.  
 

--- a/draft-ietf-quic-v2.md
+++ b/draft-ietf-quic-v2.md
@@ -208,11 +208,32 @@ are willing to suffer a round-trip penalty if they are incorrect.
 # Applicability
 
 This version of QUIC provides no change from QUIC version 1 relating to the
-capabilities available to applications. Therefore, all Application Layer
+capabilities available to applications. Therefore, most Application Layer
 Protocol Negotiation (ALPN) ({{?RFC7301}}) codepoints specified to operate over
-QUICv1 can also operate over this version of QUIC.
+QUICv1 can also operate over this version of QUIC. Applications SHOULD NOT
+require new ALPNs for QUICv2 unless there is a specific performance or
+interoperability concern.
 
 All QUIC extensions defined to work with version 1 also work with version 2.
+
+## The HTTP/3 Exception
+
+HTTP/3 can use the ALPN codepoint to discover QUIC versions via the Alt-Svc
+HTTP field {{?RFC7838}}. If different QUIC versions use the same HTTP/3 ALPN, a
+client might discover QUIC support via Alt-Svc on a TCP connection, and then
+try QUIC only to find the server is incompatible. Therefore, HTTP/3 is an
+exception to the principle that new QUIC versions do not require new ALPN
+codepoints.  
+
+Therefore, HTTP/3 servers using QUIC version 2 MUST accept the "h3v2" ALPN for
+QUICv2 connections. Clients SHOULD request this ALPN over QUICv2. Servers MAY
+accept the "h3" ALPN over version 2 to improve compatibility with QUICv2
+clients supporting unmodified applications, but MUST NOT advertise the "h3"
+ALPN via Alt-Svc unless they also support QUIC version 1.
+
+A client request for either ALPN does not prevent a compatible version
+negotiation. As part of the translation of the Client Initial from one version
+to another, the server updates the ALPN accordingly.
 
 # Security Considerations
 
@@ -237,6 +258,15 @@ Specification: This Document
 Change Controller: IETF
 
 Contact: QUIC WG
+
+This document also requests that IANA add the following entry to the TLS
+Application-Layer Protocol Negotiation (ALPN) Protocol IDs registry:
+
+Protocol: HTTP/3 over QUICv2
+
+Identification Sequence: 0x68 0x33 0x76 0x32 ("h3v2")
+
+Reference: This Document
 
 --- back
 


### PR DESCRIPTION
Fixes #30.

I would personally prefer that we just add a Alt-Svc parameter and suck up the (likely rare) edge cases where this causes a 1RTT penalty, but making an exception for HTTP/3 seems like a reasonable compromise.

I'm open to the idea that this document now updates draft-ietf-http-quic, or even RFC7301. Just let me know if you think I should add it.