### PR TITLE
Test vector

### DIFF
--- a/draft-ietf-quic-v2.md
+++ b/draft-ietf-quic-v2.md
@@ -240,36 +240,30 @@ Contact: QUIC WG
 
 --- back
 
-# Sample Packet Protection
-
-These test vectors are copied verbatim from {{QUIC-TLS}}, except (of course)
-where the derived values differ.
+# Sample Packet Protection {#test-vectors}
 
 This section shows examples of packet protection so that implementations can be
-verified incrementally. Samples of initial packets from both client and server
+verified incrementally. Samples of Initial packets from both client and server
 plus a Retry packet are defined. These packets use an 8-byte client-chosen
-Destination Connection ID of 0x8394c8f03e515708.
+Destination Connection ID of 0x8394c8f03e515708. Some intermediate values are
+included. All values are shown in hexadecimal.
+
 
 ## Keys
 
 The labels generated during the execution of the HKDF-Expand-Label function
-that is, HkdfLabel.label) and part of the value given to the HKDF-Expand
+(that is, HkdfLabel.label) and part of the value given to the HKDF-Expand
 function in order to produce its output are:
 
-client in: (unchanged from QUICv1)
-00200f746c73313320636c69656e7420696e00
+client in:  00200f746c73313320636c69656e7420696e00
 
-server in: (unchanged from QUICv1)
-00200f746c7331332073657276657220696e00
+server in:  00200f746c7331332073657276657220696e00
 
-quicv2 key:
-001010746c73313320717569637632206b657900
+quicv2 key:  001010746c73313320717569637632206b657900
 
-quicv2 iv:
-000c0f746c7331332071756963763220697600
+quicv2 iv:  000c0f746c7331332071756963763220697600
 
-quicv2 hp:
-00100f746c7331332071756963763220687000
+quicv2 hp:  00100f746c7331332071756963763220687000
 
 The initial secret is common:
 
@@ -301,24 +295,22 @@ The secrets for protecting server packets are:
 
 ~~~
 server_initial_secret
-    = HKDF-Expand-Label(initial_secret, "server in", "", 32)
+    = HKDF-Expand-Label(initial_secret, "server in","", 32)
     = 3c9bf6a9c1c8c71819876967bd8b979e
       fd98ec665edf27f22c06e9845ba0ae2f
 
-key = HKDF-Expand-Label(server_initial_secret, "quicv2 key", "", 16)
+key = HKDF-Expand-Label(server_initial_secret, "quicv2 key","", 16)
     = 15d5b4d9a2b8916aa39b1bfe574d2aad
 
-iv  = HKDF-Expand-Label(server_initial_secret, "quicv2 iv", "", 12)
+iv  = HKDF-Expand-Label(server_initial_secret, "quicv2 iv","", 12)
     = a85e7ac31cd275cbb095c626
 
-hp  = HKDF-Expand-Label(server_initial_secret, "quicv2 hp", "", 16)
+hp  = HKDF-Expand-Label(server_initial_secret, "quicv2 hp","", 16)
     = b13861cfadbb9d11ff942dd80c8fc33b
 ~~~
 
 
 ## Client Initial {#sample-client-initial}
-
-TODO: Update this to v2
 
 The client sends an Initial packet.  The unprotected payload of this packet
 contains the following CRYPTO frame, plus enough PADDING frames to make a
@@ -340,7 +332,7 @@ number, 1162 bytes of frames, and the 16-byte authentication tag.  The header
 includes the connection ID and a packet number of 2:
 
 ~~~
-c300000001088394c8f03e5157080000449e00000002
+d3709a50c4088394c8f03e5157080000449e00000002
 ~~~
 
 Protecting the payload produces output that is sampled for header protection.
@@ -348,65 +340,63 @@ Because the header uses a 4-byte packet number encoding, the first 16 bytes of
 the protected payload is sampled and then applied to the header as follows:
 
 ~~~
-sample = d1b1c98dd7689fb8ec11d242b123dc9b
+sample = 23b8e610589c83c92d0e97eb7a6e5003
 
 mask = AES-ECB(hp, sample)[0..4]
-     = 437b9aec36
+     = 8e4391d84a
 
 header[0] ^= mask[0] & 0x0f
-     = c0
+     = dd
 header[18..21] ^= mask[1..4]
-     = 7b9aec34
-header = c000000001088394c8f03e5157080000449e7b9aec34
+     = 4391d848
+header = dd709a50c4088394c8f03e5157080000449e4391d848
 ~~~
 
 The resulting protected packet is:
 
 ~~~
-c000000001088394c8f03e5157080000 449e7b9aec34d1b1c98dd7689fb8ec11
-d242b123dc9bd8bab936b47d92ec356c 0bab7df5976d27cd449f63300099f399
-1c260ec4c60d17b31f8429157bb35a12 82a643a8d2262cad67500cadb8e7378c
-8eb7539ec4d4905fed1bee1fc8aafba1 7c750e2c7ace01e6005f80fcb7df6212
-30c83711b39343fa028cea7f7fb5ff89 eac2308249a02252155e2347b63d58c5
-457afd84d05dfffdb20392844ae81215 4682e9cf012f9021a6f0be17ddd0c208
-4dce25ff9b06cde535d0f920a2db1bf3 62c23e596d11a4f5a6cf3948838a3aec
-4e15daf8500a6ef69ec4e3feb6b1d98e 610ac8b7ec3faf6ad760b7bad1db4ba3
-485e8a94dc250ae3fdb41ed15fb6a8e5 eba0fc3dd60bc8e30c5c4287e53805db
-059ae0648db2f64264ed5e39be2e20d8 2df566da8dd5998ccabdae053060ae6c
-7b4378e846d29f37ed7b4ea9ec5d82e7 961b7f25a9323851f681d582363aa5f8
-9937f5a67258bf63ad6f1a0b1d96dbd4 faddfcefc5266ba6611722395c906556
-be52afe3f565636ad1b17d508b73d874 3eeb524be22b3dcbc2c7468d54119c74
-68449a13d8e3b95811a198f3491de3e7 fe942b330407abf82a4ed7c1b311663a
-c69890f4157015853d91e923037c227a 33cdd5ec281ca3f79c44546b9d90ca00
-f064c99e3dd97911d39fe9c5d0b23a22 9a234cb36186c4819e8b9c5927726632
-291d6a418211cc2962e20fe47feb3edf 330f2c603a9d48c0fcb5699dbfe58964
-25c5bac4aee82e57a85aaf4e2513e4f0 5796b07ba2ee47d80506f8d2c25e50fd
-14de71e6c418559302f939b0e1abd576 f279c4b2e0feb85c1f28ff18f58891ff
-ef132eef2fa09346aee33c28eb130ff2 8f5b766953334113211996d20011a198
-e3fc433f9f2541010ae17c1bf202580f 6047472fb36857fe843b19f5984009dd
-c324044e847a4f4a0ab34f719595de37 252d6235365e9b84392b061085349d73
-203a4a13e96f5432ec0fd4a1ee65accd d5e3904df54c1da510b0ff20dcc0c77f
-cb2c0e0eb605cb0504db87632cf3d8b4 dae6e705769d1de354270123cb11450e
-fc60ac47683d7b8d0f811365565fd98c 4c8eb936bcab8d069fc33bd801b03ade
-a2e1fbc5aa463d08ca19896d2bf59a07 1b851e6c239052172f296bfb5e724047
-90a2181014f3b94a4e97d117b4381303 68cc39dbb2d198065ae3986547926cd2
-162f40a29f0c3c8745c0f50fba3852e5 66d44575c29d39a03f0cda721984b6f4
-40591f355e12d439ff150aab7613499d bd49adabc8676eef023b15b65bfc5ca0
-6948109f23f350db82123535eb8a7433 bdabcb909271a6ecbcb58b936a88cd4e
-8f2e6ff5800175f113253d8fa9ca8885 c2f552e657dc603f252e1a8e308f76f0
-be79e2fb8f5d5fbbe2e30ecadd220723 c8c0aea8078cdfcb3868263ff8f09400
-54da48781893a7e49ad5aff4af300cd8 04a6b6279ab3ff3afb64491c85194aab
-760d58a606654f9f4400e8b38591356f bf6425aca26dc85244259ff2b19c41b9
-f96f3ca9ec1dde434da7d2d392b905dd f3d1f9af93d1af5950bd493f5aa731b4
-056df31bd267b6b90a079831aaf579be 0a39013137aac6d404f518cfd4684064
-7e78bfe706ca4cf5e9c5453e9f7cfd2b 8b4c8d169a44e55c88d4a9a7f9474241
-e221af44860018ab0856972e194cd934
+dd709a50c4088394c8f03e5157080000 449e4391d84823b8e610589c83c92d0e
+97eb7a6e5003f57764c5c7f0095ba54b 90818f1bfeecc1c97c54fc731edbd2a2
+44e3b1e639a9bc75ed545b98649343b2 53615ec6b3e4df0fd2e7fe9d691a09e6
+a144b436d8a2c088a404262340dfd995 ec3865694e3026ecd8c6d2561a5a3667
+2a1005018168c0f081c10e2bf14d550c 977e28bb9a759c57d0f7ffb1cdfb40bd
+774dec589657542047dffefa56fc8089 a4d1ef379c81ba3df71a05ddc7928340
+775910feb3ce4cbcfd8d253edd05f161 458f9dc44bea017c3117cca7065a315d
+eda9464e672ec80c3f79ac993437b441 ef74227ecc4dc9d597f66ab0ab8d214b
+55840c70349d7616cbe38e5e1d052d07 f1fedb3dd3c4d8ce295724945e67ed2e
+efcd9fb52472387f318e3d9d233be7df c79d6bf6080dcbbb41feb180d7858849
+7c3e439d38c334748d2b56fd19ab364d 057a9bd5a699ae145d7fdbc8f5777518
+1b0a97c3bdedc91a555d6c9b8634e106 d8c9ca45a9d5450a7679edc545da9102
+5bc93a7cf9a023a066ffadb9717ffaf3 414c3b646b5738b3cc4116502d18d79d
+8227436306d9b2b3afc6c785ce3c817f eb703a42b9c83b59f0dcef1245d0b3e4
+0299821ec19549ce489714fe2611e72c d882f4f70dce7d3671296fc045af5c9f
+630d7b49a3eb821bbca60f1984dce664 91713bfe06001a56f51bb3abe92f7960
+547c4d0a70f4a962b3f05dc25a34bbe8 30a7ea4736d3b0161723500d82beda9b
+e3327af2aa413821ff678b2a876ec4b0 0bb605ffcc3917ffdc279f187daa2fce
+8cde121980bba8ec8f44ca562b0f1319 14c901cfbd847408b778e6738c7bb5b1
+b3f97d01b0a24dcca40e3bed29411b1b a8f60843c4a241021b23132b9500509b
+9a3516d4a9dd41d3bacbcd426b451393 521828afedcf20fa46ac24f44a8e2973
+30b16705d5d5f798eff9e9134a065979 87a1db4617caa2d93837730829d4d89e
+16413be4d8a8a38a7e6226623b64a820 178ec3a66954e10710e043ae73dd3fb2
+715a0525a46343fb7590e5eac7ee55fc 810e0d8b4b8f7be82cd5a214575a1b99
+629d47a9b281b61348c8627cab38e2a6 4db6626e97bb8f77bdcb0fee476aedd7
+ba8f5441acaab00f4432edab3791047d 9091b2a753f035648431f6d12f7d6a68
+1e64c861f4ac911a0f7d6ec0491a78c9 f192f96b3a5e7560a3f056bc1ca85983
+67ad6acb6f2e034c7f37beeb9ed470c4 304af0107f0eb919be36a86f68f37fa6
+1dae7aff14decd67ec3157a11488a14f ed0142828348f5f608b0fe03e1f3c0af
+3acca0ce36852ed42e220ae9abf8f890 6f00f1b86bff8504c8f16c784fd52d25
+e013ff4fda903e9e1eb453c1464b1196 6db9b28e8f26a3fc419e6a60a48d4c72
+14ee9c6c6a12b68a32cac8f61580c64f 29cb6922408783c6d12e725b014fe485
+cd17e484c5952bf99bc94941d4b1919d 04317b8aa1bd3754ecbaa10ec227de85
+40695bf2fb8ee56f6dc526ef366625b9 1aa4970b6ffa5c8284b9b5ab852b905f
+9d83f5669c0535bc377bcc05ad5e48e2 81ec0e1917ca3c6a471f8da0894bc82a
+c2a8965405d6eef3b5e293a88fda203f 09bdc72757b107ab14880eaa3ef7045b
+580f4821ce6dd325b5a90655d8c5b55f 76fb846279a9b518c5e9b9a21165c509
+3ed49baaacadf1f21873266c767f6769
 ~~~
 
 
 ## Server Initial
-
-TODO: Update this to v2
 
 The server sends the following payload in response, including an ACK frame, a
 CRYPTO frame, and no PADDING frames:
@@ -422,43 +412,43 @@ The header from the server includes a new connection ID and a 2-byte packet
 number encoding for a packet number of 1:
 
 ~~~
-c1000000010008f067a5502a4262b50040750001
+d1709a50c40008f067a5502a4262b50040750001
 ~~~
 
 As a result, after protection, the header protection sample is taken starting
 from the third protected byte:
 
 ~~~
-sample = 2cd0991cd25b0aac406a5816b6394100
-mask   = 2ec0d8356a
-header = cf000000010008f067a5502a4262b5004075c0d9
+sample = ebb7972fdce59d50e7e49ff2a7e8de76
+mask   = 41103f438e
+header = d0709a50c40008f067a5502a4262b5004075103e
 ~~~
 
 The final protected packet is then:
 
 ~~~
-cf000000010008f067a5502a4262b500 4075c0d95a482cd0991cd25b0aac406a
-5816b6394100f37a1c69797554780bb3 8cc5a99f5ede4cf73c3ec2493a1839b3
-dbcba3f6ea46c5b7684df3548e7ddeb9 c3bf9c73cc3f3bded74b562bfb19fb84
-022f8ef4cdd93795d77d06edbb7aaf2f 58891850abbdca3d20398c276456cbc4
-2158407dd074ee
+d0709a50c40008f067a5502a4262b500 4075103e63b4ebb7972fdce59d50e7e4
+9ff2a7e8de76b0cd8c10100a1f13d549 dd6fe801588fb14d279bef8d7c53ef62
+66a9a7a1a5f2fa026c236a5bf8df5aa0 f9d74773aeccfffe910b0f76814b5e33
+f7b7f8ec278d23fd8c7a9e66856b8bbe 72558135bca27c54d63fcc902253461c
+fc089d4e6b9b19
 ~~~
+
 
 ## Retry
 
 This shows a Retry packet that might be sent in response to the Initial packet
 in {{sample-client-initial}}. The integrity check includes the client-chosen
-connection ID value of 0x8394c8f03e515708, but that value is not included in the
-final retry packet:
+connection ID value of 0x8394c8f03e515708, but that value is not
+included in the final Retry packet:
 
 ~~~
-cf709a50c40008f067a5502a4262b574  6f6b656e1dc71130cd1ed39d6efcee5c
+cf709a50c40008f067a5502a4262b574 6f6b656e1dc71130cd1ed39d6efcee5c
 85806501
 ~~~
 
-## ChaCha20-Poly1305 Short Header Packet
 
-TODO: Update this to v2
+## ChaCha20-Poly1305 Short Header Packet
 
 This example shows some of the steps required to protect a packet with
 a short header.  This example uses AEAD_CHACHA20_POLY1305.
@@ -473,20 +463,20 @@ secret
     = 9ac312a7f877468ebe69422748ad00a1
       5443f18203a07d6060f688f30f21632b
 
-key = HKDF-Expand-Label(secret, "quic key", "", 32)
-    = c6d98ff3441c3fe1b2182094f69caa2e
-      d4b716b65488960a7a984979fb23e1c8
+key = HKDF-Expand-Label(secret, "quicv2 key", "", 32)
+    = 3bfcddd72bcf02541d7fa0dd1f5f9eee
+      a817e09a6963a0e6c7df0f9a1bab90f2
 
-iv  = HKDF-Expand-Label(secret, "quic iv", "", 12)
-    = e0459b3474bdd0e44a41c144
+iv  = HKDF-Expand-Label(secret, "quicv2 iv", "", 12)
+    = a6b5bc6ab7dafce30ffff5dd
 
-hp  = HKDF-Expand-Label(secret, "quic hp", "", 32)
-    = 25a282b9e82f06f21f488917a4fc8f1b
-      73573685608597d0efcb076b0ab7a7a4
+hp  = HKDF-Expand-Label(secret, "quicv2 hp", "", 32)
+    = d659760d2ba434a226fd37b35c69e2da
+      8211d10c4f12538787d65645d5d1b8e2
 
-ku  = HKDF-Expand-Label(secret, "quic ku", "", 32)
-    = 1223504755036d556342ee9361d25342
-      1a826c9ecdf3c7148684b36b714881f9
+ku  = HKDF-Expand-Label(secret, "quicv2 ku", "", 32)
+    = c69374c49e3d2a9466fa689e49d476db
+      5d0dfbc87d32ceeaa6343fd0ae4c7d88
 ~~~
 
 The following shows the steps involved in protecting a minimal packet with an
@@ -498,25 +488,25 @@ packet number is encoded on fewer bytes.
 
 ~~~
 pn                 = 654360564 (decimal)
-nonce              = e0459b3474bdd0e46d417eb0
+nonce              = a6b5bc6ab7dafce328ff4a29
 unprotected header = 4200bff4
 payload plaintext  = 01
-payload ciphertext = 655e5cd55c41f69080575d7999c25a5bfb
+payload ciphertext = 0ae7b6b932bc27d786f4bc2bb20f2162ba
 ~~~
 
 The resulting ciphertext is the minimum size possible. One byte is skipped to
 produce the sample for header protection.
 
 ~~~
-sample = 5e5cd55c41f69080575d7999c25a5bfb
-mask   = aefefe7d03
-header = 4cfe4189
+sample = e7b6b932bc27d786f4bc2bb20f2162ba
+mask   = 97580e32bf
+header = 5558b1c6
 ~~~
 
-The protected packet is the smallest possible packet size of 21 bytes.
+The protected packet is the smallest possible packet size of 5 bytes.
 
 ~~~
-packet = 4cfe4189655e5cd55c41f69080575d7999c25a5bfb
+packet = 5558b1c60ae7b6b932bc27d786f4bc2bb20f2162ba
 ~~~
 
 # Changelog

--- a/draft-ietf-quic-v2.md
+++ b/draft-ietf-quic-v2.md
@@ -295,17 +295,17 @@ The secrets for protecting server packets are:
 
 ~~~
 server_initial_secret
-    = HKDF-Expand-Label(initial_secret, "server in","", 32)
+    = HKDF-Expand-Label(initial_secret, "server in", "", 32)
     = 3c9bf6a9c1c8c71819876967bd8b979e
       fd98ec665edf27f22c06e9845ba0ae2f
 
-key = HKDF-Expand-Label(server_initial_secret, "quicv2 key","", 16)
+key = HKDF-Expand-Label(server_initial_secret, "quicv2 key", "", 16)
     = 15d5b4d9a2b8916aa39b1bfe574d2aad
 
-iv  = HKDF-Expand-Label(server_initial_secret, "quicv2 iv","", 12)
+iv  = HKDF-Expand-Label(server_initial_secret, "quicv2 iv", "", 12)
     = a85e7ac31cd275cbb095c626
 
-hp  = HKDF-Expand-Label(server_initial_secret, "quicv2 hp","", 16)
+hp  = HKDF-Expand-Label(server_initial_secret, "quicv2 hp", "", 16)
     = b13861cfadbb9d11ff942dd80c8fc33b
 ~~~
 
@@ -503,7 +503,7 @@ mask   = 97580e32bf
 header = 5558b1c6
 ~~~
 
-The protected packet is the smallest possible packet size of 5 bytes.
+The protected packet is the smallest possible packet size of 21 bytes.
 
 ~~~
 packet = 5558b1c60ae7b6b932bc27d786f4bc2bb20f2162ba
@@ -517,7 +517,7 @@ packet = 5558b1c60ae7b6b932bc27d786f4bc2bb20f2162ba
 ## since draft-ietf-quic-v2-00
 
 * Expanded requirements for compatible version negotiation
-* Added Initial Key and Retry test vector
+* Added test vectors
 * Greased the packet type codepoints
 * Random version number
 * Clarified requirement to use QUIC-VN


### PR DESCRIPTION
Fixes for #17.

The code that generated these was tested against the RFC 9001 version 1 test vectors.