### PR TITLE
support v1 language

### DIFF
--- a/draft-ietf-quic-v2.md
+++ b/draft-ietf-quic-v2.md
@@ -145,7 +145,9 @@ with clients. In particular, HTTP clients often use Alt-Svc {{?RFC7838}} to
 discover QUIC support. As this mechanism does not currently distinguish between
 QUIC versions, HTTP servers that support multiple versions reduce the
 probability of incompatibility and the cost associated with QUIC version
-negotiation or TCP fallback.
+negotiation or TCP fallback. For example, an origin advertising support for "h3" in Alt-Svc
+SHOULD support QUIC version 1 as it was the original QUIC version used by HTTP/3 and
+therefore some clients will only support that version.
 
 Any QUIC endpoint that supports multiple versions MUST meet the minimum
 requirements described in {{QUIC-VN}} to prevent version downgrade attacks.

--- a/draft-ietf-quic-v2.md
+++ b/draft-ietf-quic-v2.md
@@ -152,12 +152,8 @@ requirements described in {{QUIC-VN}} to prevent version downgrade attacks.
 
 Note that version 2 meets that document's definition of a compatible version
 with version 1. Therefore, servers can use compatible negotiation to switch a
-connection between the two versions.
-
-A server might fully support version 2 but merely parse Initial packets from
-version 1, or vice versa. Such servers SHOULD use compatible negotiation instead
-of sending a Version Negotiation packet to initiate incompatible version
-negotiation to avoid the delay penalty of the latter.
+connection between the two versions. Endpoints that support both versions
+SHOULD support compatible version negotiation to avoid a round trip.
 
 ## Compatible Negotiation Requirements
 

--- a/draft-ietf-quic-v2.md
+++ b/draft-ietf-quic-v2.md
@@ -139,13 +139,15 @@ nonce = 0x141b99c239b03e785d6a2e9f
 
 # Version Negotiation Considerations
 
-QUIC version 2 endpoints SHOULD also support QUIC version 1. Any QUIC endpoint
-that supports multiple versions MUST meet the minimum requirements described in
-{{QUIC-VN}} to prevent version downgrade attacks.
+QUIC version 2 endpoints SHOULD also support QUIC version 1, as at the time of
+writing version 1 is far more common and version 2 is not intended to deprecate
+version 1. Any QUIC endpoint that supports multiple versions MUST meet the
+minimum requirements described in {{QUIC-VN}} to prevent version downgrade
+attacks.
 
 Note that version 2 meets that document's definition of a compatible version
-with version 1. Therefore, v2-capable servers MUST use compatible version
-negotiation unless they do not support version 1.
+with version 1. Therefore, servers can use compatible negotiation to switch a
+connection between the two versions.
 
 ## Compatible Negotiation Requirements
 

--- a/draft-ietf-quic-v2.md
+++ b/draft-ietf-quic-v2.md
@@ -139,15 +139,18 @@ nonce = 0x141b99c239b03e785d6a2e9f
 
 # Version Negotiation Considerations
 
-QUIC version 2 endpoints SHOULD also support QUIC version 1, as at the time of
-writing version 1 is far more common and version 2 is not intended to deprecate
-version 1. Any QUIC endpoint that supports multiple versions MUST meet the
-minimum requirements described in {{QUIC-VN}} to prevent version downgrade
-attacks.
+QUIC version 2 endpoints SHOULD also support QUIC version 1, as version 2 is
+both less common than, and not intended to deprecate, version 1. Any QUIC
+endpoint that supports multiple versions MUST meet the minimum requirements
+described in {{QUIC-VN}} to prevent version downgrade attacks.
 
 Note that version 2 meets that document's definition of a compatible version
 with version 1. Therefore, servers can use compatible negotiation to switch a
 connection between the two versions.
+
+A server that can parse version 1, but cannot fully support it, SHOULD use
+compatible negotiation instead of sending a Version Negotiation packet to
+initiate incompatible version negotiation.
 
 ## Compatible Negotiation Requirements
 

--- a/draft-ietf-quic-v2.md
+++ b/draft-ietf-quic-v2.md
@@ -139,18 +139,25 @@ nonce = 0x141b99c239b03e785d6a2e9f
 
 # Version Negotiation Considerations
 
-QUIC version 2 endpoints SHOULD also support QUIC version 1, as version 2 is
-both less common than, and not intended to deprecate, version 1. Any QUIC
-endpoint that supports multiple versions MUST meet the minimum requirements
-described in {{QUIC-VN}} to prevent version downgrade attacks.
+QUIC version 2 is not intended to deprecate version 1. Endpoints that support
+version 2 might continue support for version 1 to maximize compatibility
+with clients. In particular, HTTP clients often use Alt-Svc {{?RFC7838}} to
+discover QUIC support. As this mechanism does not currently distinguish between
+QUIC versions, HTTP servers that support multiple versions reduce the
+probability of incompatibility and the cost associated with QUIC version
+negotiation or TCP fallback.
+
+Any QUIC endpoint that supports multiple versions MUST meet the minimum
+requirements described in {{QUIC-VN}} to prevent version downgrade attacks.
 
 Note that version 2 meets that document's definition of a compatible version
 with version 1. Therefore, servers can use compatible negotiation to switch a
 connection between the two versions.
 
-A server that can parse version 1, but cannot fully support it, SHOULD use
-compatible negotiation instead of sending a Version Negotiation packet to
-initiate incompatible version negotiation.
+A server might fully support version 2 but merely parse Initial packets from
+version 1, or vice versa. Such servers SHOULD use compatible negotiation instead
+of sending a Version Negotiation packet to initiate incompatible version
+negotiation to avoid the delay penalty of the latter.
 
 ## Compatible Negotiation Requirements
 
@@ -210,7 +217,7 @@ Clients interested in combating firewall ossification can initiate a connection
 using version 2 if they are either reasonably certain the server supports it, or
 are willing to suffer a round-trip penalty if they are incorrect.
 
-# Applicability
+# Applicability {#applicability}
 
 This version of QUIC provides no change from QUIC version 1 relating to the
 capabilities available to applications. Therefore, all Application Layer


### PR DESCRIPTION
Fixes #35.

The original intent was to recommend compatible VN. But that doesn't make any sense: compatible VN is something that the server initiates between versions that are at least partially supported. The client doesn't really have any control except that it can omit versions from the TP.

Incompatible VN cannot happen between mutually supported versions, and the client is in control.