### PR TITLE
octets -> bytes

### DIFF
--- a/draft-ietf-quic-v2.md
+++ b/draft-ietf-quic-v2.md
@@ -51,7 +51,7 @@ contains the draft:
 # Introduction
 
 QUIC {{QUIC}} has numerous extension points, including the version number
-that occupies the second through fifth byte of every long header (see
+that occupies the second through fifth bytes of every long header (see
 {{?RFC8999}}). If experimental versions are rare, and QUIC version 1 constitutes
 the vast majority of QUIC traffic, there is the potential for middleboxes to
 ossify on the version bytes always being 0x00000001.

--- a/draft-ietf-quic-v2.md
+++ b/draft-ietf-quic-v2.md
@@ -51,10 +51,10 @@ contains the draft:
 # Introduction
 
 QUIC {{QUIC}} has numerous extension points, including the version number
-that occupies the second through fifth octets of every long header (see
+that occupies the second through fifth byte of every long header (see
 {{?RFC8999}}). If experimental versions are rare, and QUIC version 1 constitutes
 the vast majority of QUIC traffic, there is the potential for middleboxes to
-ossify on the version octets always being 0x00000001.
+ossify on the version bytes always being 0x00000001.
 
 Furthermore, version 1 Initial packets are encrypted with keys derived from a
 universally known salt, which allow observers to inspect the contents of these


### PR DESCRIPTION
Invariants uses `bytes`, let's be consistent